### PR TITLE
[염정운] 코호트 분석 부분 프론트엔드 백엔드 데이터 바인딩 연결 테스트

### DIFF
--- a/subsubclipclop/src/infrastructure/api/cohortApi.ts
+++ b/subsubclipclop/src/infrastructure/api/cohortApi.ts
@@ -1,9 +1,28 @@
 // // /infrastructure/api/cohortApi.ts
 
-// // 행동 패턴 API
-// export async function fetchBehaviorPatternApi() {
-//   return fetch("/api/cohorts/behavior-pattern").then(res => res.json());
-// }
+// 행동 패턴 API
+export async function fetchBehaviorPatternApi(companyNo: number) {
+  return fetch("/api/cohorts/behavior-pattern", {
+    method: "POST", // ✅ POST 방식
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({ companyNo }) // ✅ 요청 바디에 JSON 전달
+  })
+    .then(res => {
+      console.log("응답 상태:", res.status);
+      return res.json();
+    })
+    .then(data => {
+      console.log("받은 데이터:", data);
+      return data;
+    })
+    .catch(err => {
+      console.error("API 요청 에러:", err);
+    });
+}
+
+
 
 // // 잔존율 히트맵 API
 // export async function fetchRemainHeatmapApi() {
@@ -17,10 +36,10 @@
 
 // /infrastructure/api/cohortApi.ts
 
-// 행동 패턴 API
-export async function fetchBehaviorPatternApi() {
-  return fetch("/mock/behavior-pattern.json").then(res => res.json());
-}
+// // 행동 패턴 API
+// export async function fetchBehaviorPatternApi() {
+//   return fetch("/mock/behavior-pattern.json").then(res => res.json());
+// }
 
 // 잔존율 히트맵 API
 export async function fetchRemainHeatmapApi() {

--- a/subsubclipclop/src/infrastructure/api/cohortApi.ts
+++ b/subsubclipclop/src/infrastructure/api/cohortApi.ts
@@ -18,8 +18,9 @@ export async function fetchBehaviorPatternApi(companyNo: number) {
       return data;
     })
     .catch(err => {
-      console.error("API 요청 에러:", err);
-    });
+        console.error("API 요청 에러:", err);
+        throw err; // 오류를 호출자에게 전파
+      });
 }
 
 

--- a/subsubclipclop/src/infrastructure/repositories/CohortRepositoryImpl.ts
+++ b/subsubclipclop/src/infrastructure/repositories/CohortRepositoryImpl.ts
@@ -6,7 +6,7 @@ import { CohortInsightMapper } from "@/adapters/mappers/CohortInsightMapper";
 
 export class CohortRepositoryImpl implements CohortRepository {
   async fetchBehaviorPattern() {
-    const rawData = await fetchBehaviorPatternApi();
+    const rawData = await fetchBehaviorPatternApi(1);
     return CohortBehaviorPatternMapper(rawData); // ✅ 매퍼 사용
   }
 

--- a/subsubclipclop/src/main.tsx
+++ b/subsubclipclop/src/main.tsx
@@ -6,9 +6,9 @@ import App from './App';
 import './styles/index.css';
 
 createRoot(document.getElementById('root')!).render(
-  <StrictMode>
+  // <StrictMode>
     <BrowserRouter>
       <App />
     </BrowserRouter>
-  </StrictMode>
+  // </StrictMode>
 );

--- a/subsubclipclop/vite.config.ts
+++ b/subsubclipclop/vite.config.ts
@@ -22,4 +22,13 @@ export default defineConfig({
       input: 'src/main.tsx', // main 진입점 위치
     },
   },
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:8001", // 스프링 서버 주소
+        changeOrigin: true,
+        secure: false
+      }
+    }
+  },
 });


### PR DESCRIPTION
프론트엔드 백엔드 데이터 바인딩 연결 테스트를 할 수 있도록 수정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 개발 서버에서 `/api`로 시작하는 요청이 자동으로 백엔드(`http://localhost:8001`)로 프록시됩니다.

- **버그 수정**
  - 행동 패턴 데이터를 불러올 때 회사 번호를 포함하여 API 요청 방식을 개선하였습니다.

- **기타**
  - React StrictMode가 비활성화되어 렌더링 시 엄격 모드 검사 기능이 해제되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->