### PR TITLE
라우터 경로수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ const initializeToken = useAuthStore((state) => state.initializeToken);
       <Route path="/signup" element={<SignupPage />} />
       {/* 향후 다른 페이지 추가 시 아래에 계속 확장 가능 */}
       <Route
-        path="/analytics/double/clusterselect"
+        path="/analytics/single/clusterselect"
         element={
           <ProtectedRoute>
             <AnalyticsCohortSingleClusterSelectPage />

--- a/src/presentation/components/molecules/SignupPasswordForm.tsx
+++ b/src/presentation/components/molecules/SignupPasswordForm.tsx
@@ -91,7 +91,7 @@ export const SignUpPasswordForm = ({ form, setForm, onOtpSent, emailCheckResult 
         />
         <label>
           I agree with the{" "}
-          <a href="/privacy" className="text-blue-600 underline">Privacy Policy</a>
+          <a href="src\assets\PrivacyPolicy.pdf" download="PrivacyPolicy.pdf" className="text-blue-600 underline">Privacy Policy</a>
         </label>
       </div>
       <div className="pt-2 justify-center items-center">


### PR DESCRIPTION
라우터 경로 수정
"/analytics/double/clusterselect" 여기 로그아웃 버튼 만들어서 테스트 함
로그아웃 버튼 필요한 페이지 만드시는분 <LogoutButton> 사용하시면 됩니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 단일 코호트 분석 페이지의 경로가 `/analytics/double/clusterselect`에서 `/analytics/single/clusterselect`로 수정되었습니다.
- **기능 개선**
  - 회원가입 폼의 개인정보처리방침 링크가 웹페이지 이동에서 PDF 파일 다운로드로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->