### PR TITLE
[염정운] 코호트 결과 창에서 히트맵과 시각화만 먼저 출력 되도록 변경, 요청 리스트에서 최근의 것이 먼저 출력되도록 함.

### DIFF
--- a/src/application/viewModels/CohortViewModel.ts
+++ b/src/application/viewModels/CohortViewModel.ts
@@ -112,11 +112,16 @@ export function useCohortHistoryViewModel(clusterType: string) {
 
     try {
       setLoading(true);
+
       const result = await useCase.execute(infoDbNo, analysisNo);
+
+      const sorted = result.sort((a, b) =>
+        new Date(b.lastModified).getTime() - new Date(a.lastModified).getTime()
+      );
 
       const start = pageNumber * PAGE_SIZE;
       const end = start + PAGE_SIZE;
-      const newItems = result.slice(start, end);
+      const newItems = sorted.slice(start, end);
 
       if (newItems.length < PAGE_SIZE) {
         setHasMore(false);
@@ -159,7 +164,6 @@ interface CohortResult {
   heatmap: any[];
   doughnutChart: ChartData<"doughnut", number[]> | null;
   lineChart: ChartData<"line", number[]> | null;
-  insight: string;
   userData: CohortSingleUserResponse[];
   groupData: Record<string, number[]>;
 }
@@ -173,14 +177,12 @@ interface Props {
 export function useCohortSingleCsvResultViewModel({ clusterType, infoDbNo, filename }: Props) {
   const [result, setResult] = useState<CohortResult | null>(null);
   const [rawCsv, setRawCsv] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
-
-  const [insightObj, setInsightObj] = useState<Insight | null>(null);
+  const [isLoadingMain, setIsLoadingMain] = useState(false);
+  const [errorMain, setErrorMain] = useState<Error | null>(null);
 
   useEffect(() => {
     const load = async () => {
-      setIsLoading(true);
+      setIsLoadingMain(true);
       try {
         const analysisNo = clusterMap[clusterType];
         const useCase = new GetCohortResultCsvUseCase(new CohortRepository());
@@ -191,21 +193,10 @@ export function useCohortSingleCsvResultViewModel({ clusterType, infoDbNo, filen
 
         setResult(parsed);
         setRawCsv(csvData);
-
-        const insightPath = `${infoDbNo}/cohort/${clusterType}/${cleanFilename}.csv`;
-        try {
-          const insightResponse = await axiosInstance.get<Insight>("/analysis/cohort/insight", {
-            params: { filename: insightPath },
-          });
-          setInsightObj(insightResponse.data);
-        } catch (insightError) {
-          console.warn("인사이트 데이터 로딩 실패:", insightError);
-          setInsightObj(null);
-        }
       } catch (e) {
-        setError(e instanceof Error ? e : new Error("CSV 분석 실패"));
+        setErrorMain(e instanceof Error ? e : new Error("CSV 분석 실패"));
       } finally {
-        setIsLoading(false);
+        setIsLoadingMain(false);
       }
     };
 
@@ -218,12 +209,58 @@ export function useCohortSingleCsvResultViewModel({ clusterType, infoDbNo, filen
     heatmap: result?.heatmap ?? [],
     doughnutChart: result?.doughnutChart ?? null,
     lineChart: result?.lineChart ?? null,
-    insight: insightObj,
     userData: result?.userData ?? [],
     groupData: result?.groupData ?? {},
     rawCsv,
-    isLoading,
-    error,
+    isLoadingMain,
+    errorMain,
+  };
+}
+
+interface InsightProps {
+  clusterType: string;
+  infoDbNo: number;
+  filename: string;
+}
+
+export function useCohortSingleInsightViewModel({
+  clusterType,
+  infoDbNo,
+  filename,
+}: InsightProps) {
+  const [insight, setInsight] = useState<Insight | null>(null);
+  const [isLoadingInsight, setIsLoadingInsight] = useState<boolean>(false);
+  const [errorInsight, setErrorInsight] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const loadInsight = async () => {
+      setIsLoadingInsight(true);
+      try {
+        const cleanFilename = filename.replace(/\.csv$/, "");
+        const insightPath = `${infoDbNo}/cohort/${clusterType}/${cleanFilename}.csv`;
+
+        const response = await axiosInstance.get<Insight>("/analysis/cohort/insight", {
+          params: { filename: insightPath },
+        });
+
+        setInsight(response.data);
+      } catch (error) {
+        console.warn("인사이트 로딩 실패:", error);
+        setErrorInsight(error instanceof Error ? error : new Error("Insight 로딩 실패"));
+      } finally {
+        setIsLoadingInsight(false);
+      }
+    };
+
+    if (clusterType && infoDbNo && filename) {
+      loadInsight();
+    }
+  }, [clusterType, infoDbNo, filename]);
+
+  return {
+    insight,
+    isLoadingInsight,
+    errorInsight,
   };
 }
 

--- a/src/core/utils/csvParser.ts
+++ b/src/core/utils/csvParser.ts
@@ -38,7 +38,6 @@ interface CohortResult {
   heatmap: HeatmapCell[];
   doughnutChart: ChartData<"doughnut", number[]> | null;
   lineChart: ChartData<"line", number[]> | null;
-  insight: string;
   userData: CohortSingleUserResponse[];
   groupData: Record<string, number[]>;
 }
@@ -136,13 +135,10 @@ export function parseCsvToCohortResult(csv: string): CohortResult {
     ],
   };
 
-  const insight = "각 그룹의 잔존율을 기반으로 월별 사용자 유지 현황을 확인할 수 있습니다.";
-
   return {
     heatmap,
     doughnutChart,
     lineChart,
-    insight,
     userData: [],
     groupData,
   };

--- a/src/presentation/components/organisms/CohortHistoryPanel.tsx
+++ b/src/presentation/components/organisms/CohortHistoryPanel.tsx
@@ -64,7 +64,7 @@ export function CohortHistoryPanel({ clusterType, selectedKeys, onSelect }: Prop
     if (parts.length < 4) return;
 
     if (!parts[0] || !parts[2] || !parts[3]) {
-      // console.warn("Invalid key format:", key);
+      console.warn("Invalid key format:", key);
       return;
     }
 
@@ -96,7 +96,9 @@ export function CohortHistoryPanel({ clusterType, selectedKeys, onSelect }: Prop
                   />
                 )}
                 <div className="cursor-pointer" onClick={() => handleClick(item.key)}>
-                  <p className="text-sm font-medium">{item.lastModified}</p>
+                  <p className="text-sm font-medium">
+                    {new Date(item.lastModified).toISOString().slice(0, 19).replace("T", " ") + " UTC"}
+                  </p>
                   <p className="text-xs text-gray-500 break-all">{item.key}</p>
                 </div>
               </div>

--- a/src/presentation/components/organisms/CohortHistoryPanel.tsx
+++ b/src/presentation/components/organisms/CohortHistoryPanel.tsx
@@ -5,6 +5,18 @@ import { ClockIcon } from "@heroicons/react/24/outline";
 import { useEffect, useRef, useState } from "react";
 import useIntersectionObserver from "@/core/utils/useIntersectionObserver";
 
+const formatDateTime = (dateString: string | Date): string => {
+  try {
+    const date = new Date(dateString);
+    if (isNaN(date.getTime())) {
+      return "날짜 정보 없음";
+    }
+    return date.toISOString().slice(0, 19).replace("T", " ") + " UTC";
+  } catch (error) {
+    return "날짜 정보 없음";
+  }
+};
+
 interface Props {
   clusterType: string;
   selectedKeys?: string[];
@@ -96,9 +108,7 @@ export function CohortHistoryPanel({ clusterType, selectedKeys, onSelect }: Prop
                   />
                 )}
                 <div className="cursor-pointer" onClick={() => handleClick(item.key)}>
-                  <p className="text-sm font-medium">
-                    {new Date(item.lastModified).toISOString().slice(0, 19).replace("T", " ") + " UTC"}
-                  </p>
+                  <p className="text-sm font-medium">{formatDateTime(item.lastModified)}</p>
                   <p className="text-xs text-gray-500 break-all">{item.key}</p>
                 </div>
               </div>

--- a/src/presentation/pages/AnalyticsCohortDoubleCohortResultPage.tsx
+++ b/src/presentation/pages/AnalyticsCohortDoubleCohortResultPage.tsx
@@ -5,7 +5,10 @@ import { SideMenu } from "@/presentation/layout/SideMenu";
 import { StepProgress } from "@/presentation/components/molecules/StepProgress";
 import { Header } from "@/presentation/layout/Header";
 import { CustomButton } from "@/presentation/components/atoms/CustomButton";
-import { useCohortSingleCsvResultViewModel } from "@/application/viewModels/CohortViewModel";
+import {
+  useCohortSingleCsvResultViewModel,
+  useCohortSingleInsightViewModel,
+} from "@/application/viewModels/CohortViewModel";
 import { SingleRemainHeatmapPanel } from "@/presentation/components/organisms/SingleRemainHeatmapPanel";
 import { SingleInsightPanel } from "@/presentation/components/organisms/SingleInsightPanel";
 import { SingleVisualizationPanel } from "@/presentation/components/organisms/SingleVisualizationPanel";
@@ -39,25 +42,34 @@ export default function AnalyticsCohortDoubleCohortResultPage() {
     heatmap: heatmap1,
     doughnutChart: doughnut1,
     lineChart: line1,
-    insight: insight1,
-    isLoading: isLoading1,
-    error: error1,
+    isLoadingMain: isLoading1,
+    errorMain: error1,
     groupData: groupData1,
-    rawCsv: rawCsv1, // ✅ 왼쪽 raw csv
+    rawCsv: rawCsv1,
   } = useCohortSingleCsvResultViewModel(parsed1);
+
+  const {
+    insight: insight1,
+    isLoadingInsight: isLoadingInsight1,
+    errorInsight: errorInsight1,
+  } = useCohortSingleInsightViewModel(parsed1);
 
   const {
     heatmap: heatmap2,
     doughnutChart: doughnut2,
     lineChart: line2,
-    insight: insight2,
-    isLoading: isLoading2,
-    error: error2,
+    isLoadingMain: isLoading2,
+    errorMain: error2,
     groupData: groupData2,
-    rawCsv: rawCsv2, // ✅ 오른쪽 raw csv
+    rawCsv: rawCsv2,
   } = useCohortSingleCsvResultViewModel(parsed2);
 
-  // ✅ 왼쪽 다운로드
+  const {
+    insight: insight2,
+    isLoadingInsight: isLoadingInsight2,
+    errorInsight: errorInsight2,
+  } = useCohortSingleInsightViewModel(parsed2);
+
   const handleDownload1 = useCallback(() => {
     if (!rawCsv1) return alert("왼쪽 데이터가 아직 로딩되지 않았습니다.");
     const blob = new Blob([rawCsv1], { type: "text/csv;charset=utf-8;" });
@@ -69,7 +81,6 @@ export default function AnalyticsCohortDoubleCohortResultPage() {
     URL.revokeObjectURL(url);
   }, [rawCsv1, parsed1.filename]);
 
-  // ✅ 오른쪽 다운로드
   const handleDownload2 = useCallback(() => {
     if (!rawCsv2) return alert("오른쪽 데이터가 아직 로딩되지 않았습니다.");
     const blob = new Blob([rawCsv2], { type: "text/csv;charset=utf-8;" });
@@ -119,11 +130,12 @@ export default function AnalyticsCohortDoubleCohortResultPage() {
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6 pb-20">
-            {/* 왼쪽 분석 결과 */}
+            {/* 왼쪽 */}
             <div className="space-y-6">
               <h2 className="text-xl font-bold text-center text-blue-700">
                 {parsed1.clusterType || "왼쪽 분석"}
               </h2>
+
               <SingleRemainHeatmapPanel heatmap={heatmap1} isLoading={isLoading1} error={error1} />
 
               {Object.keys(groupData1).length === 0 && !isLoading1 && !error1 ? (
@@ -141,14 +153,19 @@ export default function AnalyticsCohortDoubleCohortResultPage() {
                 />
               )}
 
-              <SingleInsightPanel insight={insight1} isLoading={isLoading1} error={error1} />
+              <SingleInsightPanel
+                insight={insight1}
+                isLoading={isLoadingInsight1}
+                error={errorInsight1}
+              />
             </div>
 
-            {/* 오른쪽 분석 결과 */}
+            {/* 오른쪽 */}
             <div className="space-y-6">
               <h2 className="text-xl font-bold text-center text-red-700">
                 {parsed2.clusterType || "오른쪽 분석"}
               </h2>
+
               <SingleRemainHeatmapPanel heatmap={heatmap2} isLoading={isLoading2} error={error2} />
 
               {Object.keys(groupData2).length === 0 && !isLoading2 && !error2 ? (
@@ -166,7 +183,11 @@ export default function AnalyticsCohortDoubleCohortResultPage() {
                 />
               )}
 
-              <SingleInsightPanel insight={insight2} isLoading={isLoading2} error={error2} />
+              <SingleInsightPanel
+                insight={insight2}
+                isLoading={isLoadingInsight2}
+                error={errorInsight2}
+              />
             </div>
           </div>
         </section>

--- a/src/presentation/pages/AnalyticsCohortSingleCohortResultPage.tsx
+++ b/src/presentation/pages/AnalyticsCohortSingleCohortResultPage.tsx
@@ -6,7 +6,10 @@ import { SideMenu } from "@/presentation/layout/SideMenu";
 import { StepProgress } from "@/presentation/components/molecules/StepProgress";
 import { Header } from "@/presentation/layout/Header";
 import { CustomButton } from "@/presentation/components/atoms/CustomButton";
-import { useCohortSingleCsvResultViewModel } from "@/application/viewModels/CohortViewModel";
+import {
+  useCohortSingleCsvResultViewModel,
+  useCohortSingleInsightViewModel,
+} from "@/application/viewModels/CohortViewModel";
 import { SingleRemainHeatmapPanel } from "@/presentation/components/organisms/SingleRemainHeatmapPanel";
 import { SingleInsightPanel } from "@/presentation/components/organisms/SingleInsightPanel";
 import { SingleVisualizationPanel } from "@/presentation/components/organisms/SingleVisualizationPanel";
@@ -33,12 +36,21 @@ export default function AnalyticsCohortSingleCohortResultPage() {
     heatmap,
     doughnutChart,
     lineChart,
-    insight,
-    isLoading,
-    error,
+    isLoadingMain,
+    errorMain,
     groupData,
     rawCsv,
   } = useCohortSingleCsvResultViewModel({
+    clusterType,
+    infoDbNo: parsedInfoDbNo,
+    filename,
+  });
+
+  const {
+    insight,
+    isLoadingInsight,
+    errorInsight,
+  } = useCohortSingleInsightViewModel({
     clusterType,
     infoDbNo: parsedInfoDbNo,
     filename,
@@ -91,9 +103,13 @@ export default function AnalyticsCohortSingleCohortResultPage() {
           </div>
 
           <div className="w-full pb-20 space-y-6">
-            <SingleRemainHeatmapPanel heatmap={heatmap} isLoading={isLoading} error={error} />
+            <SingleRemainHeatmapPanel
+              heatmap={heatmap}
+              isLoading={isLoadingMain}
+              error={errorMain}
+            />
 
-            {Object.keys(groupData).length === 0 && !isLoading && !error ? (
+            {Object.keys(groupData).length === 0 && !isLoadingMain && !errorMain ? (
               <div className="p-6 bg-white rounded-xl shadow w-full max-w-full overflow-hidden">
                 <h2 className="text-xl font-bold mb-2">시각화 결과</h2>
                 <p className="text-sm text-gray-500">그룹 데이터를 찾을 수 없습니다.</p>
@@ -102,13 +118,17 @@ export default function AnalyticsCohortSingleCohortResultPage() {
               <SingleVisualizationPanel
                 doughnutChart={doughnutChart as ChartData<"doughnut", number[]>}
                 lineChart={lineChart as ChartData<"line", number[]>}
-                isLoading={isLoading}
-                error={error}
+                isLoading={isLoadingMain}
+                error={errorMain}
                 groupData={groupData}
               />
             )}
 
-            <SingleInsightPanel insight={insight} isLoading={isLoading} error={error} />
+            <SingleInsightPanel
+              insight={insight}
+              isLoading={isLoadingInsight}
+              error={errorInsight}
+            />
           </div>
         </section>
       </main>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 코호트 인사이트 데이터를 별도로 가져오는 기능이 추가되었습니다.

- **버그 수정**
  - 코호트 히스토리 목록이 최신 수정일 기준으로 정렬되어 최신 항목이 먼저 표시됩니다.

- **리팩터**
  - 인사이트 데이터 로딩 및 에러 상태가 CSV 결과와 분리되어 관리됩니다.
  - 일부 상태 변수명이 명확하게 변경되었습니다. (예: isLoading → isLoadingMain)
  - 인사이트 필드가 코호트 결과에서 분리되어 별도의 관리로 개선되었습니다.
  - 코호트 히스토리 패널에서 날짜가 UTC 형식으로 포맷되어 표시됩니다.
  - 잘못된 키 형식에 대한 경고 로그가 활성화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->